### PR TITLE
Some bugs fixes and customizeability fixes

### DIFF
--- a/simplebnf-doc.tex
+++ b/simplebnf-doc.tex
@@ -32,10 +32,10 @@
 
 \title{%
   \textsf{simplebnf} --- A simple package to format Backus-Naur form%
-  \footnote{This file describes v0.3.0.}}
+  \footnote{This file describes v0.3.1.}}
 \author{Jay Lee\footnote{E-mail: %
   \href{mailto:jaeho.lee@snu.ac.kr}{\texttt{jaeho.lee@snu.ac.kr}}}}
-\date{2022/05/07}
+\date{2022/05/08}
 
 \begin{document}
 \maketitle

--- a/simplebnf-doc.tex
+++ b/simplebnf-doc.tex
@@ -43,9 +43,24 @@
 This package provides a simple way to typeset grammars written in Backus-Naur form (BNF).
 
 \begin{presentcommand}
-  \cmd{bnfexpr} \cmd{bnfannot}
+  \cmd{SimpleBNFDefEq}
 \end{presentcommand}
-These commands are wrappers around \cmd{texttt} and \cmd{textit} respectively.
+This command is used to typeset the definition symbol separate a nonterminal from its productions. It defaults to \SimpleBNFDefEq. It can be redefined to customized output using \verb|RenewDocumentCommand|.
+
+\begin{presentcommand}
+  \cmd{SimpleBNFDefOr}
+\end{presentcommand}
+This command is used to typeset the separator symbol between productions. It defaults to \SimpleBNFDefOr. It can be redefined to customized output using \verb|RenewDocumentCommand|.
+
+\begin{presentcommand}
+  \cmd{bnfexpr}
+\end{presentcommand}
+This command is used when typesetting the BNF nonterminal and productions. It defaults to a wrappers around \cmd{texttt}. It can be redefined to customized output using \verb|RenewDocumentCommand|.
+
+\begin{presentcommand}
+ \cmd{bnfannot}
+\end{presentcommand}
+This command is used when typesetting the annotations on nonterminals and productions. It defaults to a wrappers around \cmd{textit}. It can be redefined to customized output using \verb|RenewDocumentCommand|.
 
 \begin{presentcommand}
   \env{bnfgrammar}{text}

--- a/simplebnf.sty
+++ b/simplebnf.sty
@@ -20,11 +20,9 @@
 \cs_generate_variant:Nn \regex_split:nnNTF {nVNTF}
 \cs_generate_variant:Nn \regex_split:NnN {NVN}
 
-\tl_new:N \g__simplebnf_defeq_tl
-\tl_gset:Nn \g__simplebnf_defeq_tl { \ensuremath{\Coloneqq} }
+\NewDocumentCommand\SimpleBNFDefEq{}{\ensuremath{\Coloneqq}}
 
-\tl_new:N \g__simplebnf_defor_tl
-\tl_gset:Nn \g__simplebnf_defor_tl { \ensuremath{|} }
+\NewDocumentCommand\SimpleBNFDefOr{}{\ensuremath{|}}
 
 \seq_new:N \l__input_seq
 \seq_new:N \l__term_seq
@@ -48,7 +46,7 @@
       \bool_set_false:N \l__first_rhs
     }
     {
-      \tl_put_right:Nn \l__table_tl { \\ && \g__simplebnf_defor_tl & }
+      \tl_put_right:Nn \l__table_tl { \\ && \SimpleBNFDefOr & }
     }
 
   \tl_set:Nn \l_tmpa_tl { #1 }
@@ -58,8 +56,8 @@
     {
       \seq_pop_left:NNT \l_tmpa_seq \l_tmpa_tl
         {
-          \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{g__simplebnf_defor_tl} } \l_tmpa_tl
           \tl_put_right:Nx \l__table_tl { \bnfexpr { \l_tmpa_tl } }
+          \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{SimpleBNFDefOr} } \l_tmpa_tl
         }
 
       \tl_put_right:Nn \l__table_tl { & }
@@ -71,7 +69,7 @@
         }
     }
     {
-      \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{g__simplebnf_defor_tl} } \l_tmpa_tl
+      \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{SimpleBNFDefOr} } \l_tmpa_tl
 
       \tl_put_right:Nx \l__table_tl { \bnfexpr { \l_tmpa_tl } }
       \tl_put_right:Nn \l__table_tl { & }
@@ -152,7 +150,7 @@
             \simplebnf_typeset_lhs:n{\l__term_tl}
             \tl_put_right:Nx \l__table_tl
               {
-                & \g__simplebnf_defeq_tl &
+                & \SimpleBNFDefEq &
               }
             %% \l__keypairs_seq - (rhs:annot | rhs)...
             \regex_split:NVN \g_simplebnf_rhs_newline_r \l__keypairs_tl \l__keypairs_seq

--- a/simplebnf.sty
+++ b/simplebnf.sty
@@ -13,8 +13,8 @@
 \RequirePackage{mathtools}
 \ProvidesExplPackage
   {simplebnf}
-  {2022/05/07}
-  {0.3.0}
+  {2022/05/08}
+  {0.3.1}
   {A simple package to format Backus–Naur form}
 
 \cs_generate_variant:Nn \regex_split:nnNTF {nVNTF}

--- a/simplebnf.sty
+++ b/simplebnf.sty
@@ -56,23 +56,30 @@
     {
       \seq_pop_left:NNT \l_tmpa_seq \l_tmpa_tl
         {
-          \tl_put_right:Nx \l__table_tl { \bnfexpr { \l_tmpa_tl } }
           \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{SimpleBNFDefOr} } \l_tmpa_tl
+          % Expand only the local temporary variable.
+          \tl_put_right:No \l__table_tl
+             {
+               \exp_after:wN\bnfexpr\exp_after:wN{\l_tmpa_tl} &
+             }
         }
-
-      \tl_put_right:Nn \l__table_tl { & }
 
       \seq_pop_left:NNT \l_tmpa_seq \l_tmpb_tl
         {
-          \tl_set:Nx \l_tmpb_tl { \bnfannot { \l_tmpb_tl } }
-          \tl_put_right:NV \l__table_tl \l_tmpb_tl
+          \regex_replace_once:nnN { ^\s+ } {} \l_tmpb_tl
+          \tl_put_right:No \l__table_tl
+            {
+              \exp_after:wN\bnfannot\exp_after:wN{\l_tmpb_tl}
+            }
         }
     }
     {
       \regex_replace_all:NnN \g_simplebnf_rhs_nb_r { \c{SimpleBNFDefOr} } \l_tmpa_tl
 
-      \tl_put_right:Nx \l__table_tl { \bnfexpr { \l_tmpa_tl } }
-      \tl_put_right:Nn \l__table_tl { & }
+      \tl_put_right:No \l__table_tl
+         {
+           \exp_after:wN\bnfexpr\exp_after:wN{\l_tmpa_tl}
+         }
     }
 }
 
@@ -87,20 +94,20 @@
   \regex_split:nVNTF { : } \l_tmpa_tl \l_tmpa_seq
     {
       \seq_pop_right:NN \l_tmpa_seq \l_tmpa_tl
-      \tl_put_right:Nx \l__table_tl
+      \tl_put_right:No \l__table_tl
         {
-          \bnfannot{\l_tmpa_tl}
+          \exp_after:wN\bnfannot\exp_after:wN{\l_tmpa_tl} &
         }
       \seq_pop_left:NN \l_tmpa_seq \l_tmpa_tl
-      \tl_put_right:Nx \l__table_tl
+      \tl_put_right:No \l__table_tl
         {
-          & \bnfexpr { \l_tmpa_tl }
+          \exp_after:wN\bnfexpr\exp_after:wN{\l_tmpa_tl}
         }
     }
     {
-      \tl_put_right:Nx \l__table_tl
+      \tl_put_right:No \l__table_tl
         {
-          & \bnfexpr { \l_tmpa_tl }
+          \exp_after:wN&\exp_after:wN\bnfexpr\exp_after:wN{\l_tmpa_tl}
         }
     }
 }
@@ -148,7 +155,7 @@
             \seq_pop_left:NN \l__term_seq \l__keypairs_tl
 
             \simplebnf_typeset_lhs:n{\l__term_tl}
-            \tl_put_right:Nx \l__table_tl
+            \tl_put_right:Nn \l__table_tl
               {
                 & \SimpleBNFDefEq &
               }

--- a/simplebnf.sty
+++ b/simplebnf.sty
@@ -94,6 +94,7 @@
   \regex_split:nVNTF { : } \l_tmpa_tl \l_tmpa_seq
     {
       \seq_pop_right:NN \l_tmpa_seq \l_tmpa_tl
+      \regex_replace_once:nnN { ^\s+ } {} \l_tmpa_tl
       \tl_put_right:No \l__table_tl
         {
           \exp_after:wN\bnfannot\exp_after:wN{\l_tmpa_tl} &


### PR DESCRIPTION
I wanted to customized the grammar expression to default to math mode as below, but this uncovered a handful of minor issues.
```
\RenewDocumentCommand{\bnfexpr}{m}{\( #1 \)}
\RenewDocumentCommand{\bnfannot}{m}{\textit{(#1)}}
\RenewDocumentCommand{\SimpleBNFDefOr}{}{\;\ensuremath{|}\;}
```

For one, it seemed difficult to set expl3 variables outside the package, so I changed the variables to commands.

Some of the eager expansion tricks caused issues with some of my macros, so I tweaked them to only expand the local variables.

It looks like I also missed some leading space in one of the annotations.